### PR TITLE
Remove likely-unused dependency on Twisted

### DIFF
--- a/covidsafescan/__main__.py
+++ b/covidsafescan/__main__.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import bleak
 import asyncio
-from twisted.internet.asyncioreactor import AsyncioSelectorReactor
 import traceback
 import argparse
 import sys
@@ -26,11 +25,11 @@ async def connect(address, loop):
 def log(message):
     if args.debug:
         print(str(message), file=sys.stderr)
-async def run( loop):
-    reactor = AsyncioSelectorReactor(loop)
+
+async def run(loop):
     while True:
         log("Scanning")
-        devices = await bleak.discover(reactor=reactor, timeout=args.timeout)
+        devices = await bleak.discover(timeout=args.timeout)
         log("Found devices")
         log(", ".join([x.address for x in devices]))
         for d in devices:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-setuptools.setup(name='covidsafescan',
+setuptools.setup(
+      name='covidsafescan',
       version='1.8',
       description='Covid Safe Scanner',
       long_description=long_description,
@@ -15,5 +16,5 @@ setuptools.setup(name='covidsafescan',
       entry_points = {
           'console_scripts': ['covidsafescan=covidsafescan:__main__']
       },
-      install_requires=['bleak', 'twisted']
-     )
+      install_requires=['bleak'],
+)


### PR DESCRIPTION
It looks like `twisted` isn't actually used by this module, and bleak is happy to run without it.

It seems to still discover devices on macOS; haven't tested any further than this.