### PR TITLE
Add option to use Apple overflow area to check for CovidSafe, add passive mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install with `pip3 install covidsafescan`
 
 ```
 usage: covidsafescan [-h] [--debug] [--json] [--timeout TIMEOUT] [--once]
-                   [--no-adv-uuids] [--no-adv-manuf]
+                     [--no-adv-uuids] [--no-adv-manuf] [--apple] [--passive]
 
 Covidsafe BLE Scanner
 
@@ -21,4 +21,8 @@ optional arguments:
   --no-adv-uuids     Don't use UUIDs in advertisement frames to find CovidSafe
   --no-adv-manuf     Don't use Withings Manufacturer Data in advertisement
                      frames to find CovidSafe
+  --apple            Use Apple Overflow Area to find CovidSafe (experimental,
+                     may crash!)
+  --passive          Don't try to exchange GATT details, just report MAC
+                     addresses
 ```

--- a/covidsafescan/__main__.py
+++ b/covidsafescan/__main__.py
@@ -8,10 +8,14 @@ import sys
 import datetime
 import json
 
+APPLE_ID = 0x4c
 WITHINGS_ID = 1023
 STAGING_UUID = '17e033d3-490e-4bc9-9fe8-2f567643f4d3'
 PRODUCTION_UUID = 'b82ab3fc-1595-4f6a-80f0-fe094cc218f9'
 
+def b16(b):
+    """Converts a bytes (or array of ints) into a base16 encoded str."""
+    return base64.b16encode(bytes(b)).decode()
 
 async def connect(loop, address, uuid):
     async with bleak.BleakClient(address, loop=loop, timeout=args.timeout) as client:
@@ -34,7 +38,7 @@ def log(message):
 async def run(loop):
     while True:
         log("Scanning")
-        devices = await bleak.discover(timeout=args.timeout)
+        devices = await bleak.discover(timeout=args.timeout, filter_dups=False)
         log("Found devices")
         log(", ".join([x.address for x in devices]))
         for d in devices:
@@ -49,17 +53,40 @@ async def run(loop):
                     log('* Detected staging TraceTogether UUID')
                     uuid = STAGING_UUID
             
-            if args.adv_manuf and 'manufacturer_data' in d.metadata:
+            if 'manufacturer_data' in d.metadata:
                 manufacturer_data = d.metadata['manufacturer_data']
-                if WITHINGS_ID in manufacturer_data:
+                if args.adv_manuf and WITHINGS_ID in manufacturer_data:
                     withings_data = manufacturer_data[WITHINGS_ID]
-                    log(f'* Detected Withings manufacturer data: {base64.b16encode(bytes(withings_data)).decode()} ({withings_data})')
+                    log(f'* Detected Withings manufacturer data: {b16(withings_data)} ({withings_data})')
                     # TODO: Find the actual UUID to use. For now, assume prod.
                     if uuid is None:
                         uuid = PRODUCTION_UUID
+                if args.apple and APPLE_ID in manufacturer_data:
+                    apple_data = manufacturer_data[APPLE_ID]
+                    if len(apple_data) >= 17 and apple_data[0] == 1:
+                        log(f'* Apple Overflow Area: {b16(apple_data[1:])}')
+                        # Ref: http://www.davidgyoungtech.com/2020/05/07/hacking-the-overflow-area#background-ios-data-exchange
+                        # Apple manufacturer packet type 0x01 has a 128-bit
+                        # value. Each service is hashed to a 7-bit value,
+                        # corresponding to the bit to flip high.
+                        #
+                        # byte 1 bit 0x01 = TraceTogether (Production)
+                        # byte 3 bit 0x80 = TraceTogether (Staging)
+                        if apple_data[1] & 0x01 == 0x01:
+                            log('* Possible use of TraceTogether Prod UUID!')
+                            uuid = PRODUCTION_UUID
+                        elif apple_data[3] & 0x80 == 0x80:
+                            log('* Possible use of TraceTogether Staging UUID!')
+                            uuid = STAGING_UUID
+                        else:
+                            log('* No known UUID found. :(')
 
             if uuid is not None:
-                log("Connecting to " + d.address)
+                if args.passive:
+                    print(f'[{now}] {d.address} : {uuid}')
+                    continue
+
+                log(f'Connecting to {d.address}')
                 try:
                     result = await connect(loop, d.address, uuid)
                     if not result:
@@ -102,6 +129,17 @@ def main():
         '--no-adv-manuf',
         dest='adv_manuf', action='store_false',
         help='Don\'t use Withings Manufacturer Data in advertisement frames to find CovidSafe')
+
+    # https://github.com/xssfox/covidsafescan/pull/4
+    parser.add_argument(
+        '--apple',
+        dest='apple', action='store_true',
+        help='Use Apple Overflow Area to find CovidSafe (experimental, may crash!)')
+
+    parser.add_argument(
+        '--passive',
+        dest='passive', action='store_true',
+        help='Don\'t try to exchange GATT details, just report MAC addresses')
 
     args = parser.parse_args()
     loop = asyncio.get_event_loop()


### PR DESCRIPTION
This adds support for checking [Apple overflow area](http://www.davidgyoungtech.com/2020/05/07/hacking-the-overflow-area#hacking-the-overflow-area) for a high bit that _might_ be CovidSafe (`--apple`) and a passive mode that skips trying to connect with GATT (`--passive`).

This works better on macOS with the `filter_dups` option I added in this branch of `bleak`:

https://github.com/micolous/bleak/tree/filter-dups

I added Linux and macOS support for the parameter, but it only works properly on macOS.

I haven't enabled it by default, because this can cause Python to crash due to a problem with `bleak`'s exception handling I don't fully understand.

More notes: https://github.com/xssfox/covidsafescan/pull/4#issuecomment-626516559